### PR TITLE
A locked RED file must be born clean under the project's own gates

### DIFF
--- a/agents/machinery-build-writer.md
+++ b/agents/machinery-build-writer.md
@@ -100,7 +100,12 @@ section structure exactly.
     tests (a red design is an untrustworthy spec), and a RED exit gate of (a) every oracle stable
     id whole-token in the suite plus every guard-falsifying clause and invariant property test,
     (b) `machinery check --impl` green over the scaffolding and stubs, (c) the suite red on
-    assertions, not on its own compile errors. Only then do the tests lock; the implementer makes
+    assertions, not on its own compile errors, (d) the new files born clean under the project's
+    own formatter and linters, with the RED commit green under every non-test gate the project
+    enforces (a locked file has no legal remedy for a gate it fails later, because nobody may
+    touch it; a gate that does demand a change to a locked file is a RED-phase defect, remedied by
+    an owner-sanctioned formatting-only amendment carrying a token-identity proof, never a silent
+    edit). Only then do the tests lock; the implementer makes
     them pass without editing them; GREEN is accepted only with the locked tests AND
     `machinery check --impl` green together. Include the fallback for runtimes without subagents:
     the same agent runs RED then GREEN sequentially, and the two gate runs are what separate the
@@ -141,9 +146,10 @@ artifact. Include the `checked:` counts in your report.
   milestones with unique numbers, a `DoD:` line per milestone, the skeleton DoD citing a committed
   oracle id, and the skeleton naming its NFR-record mechanisms.
 - The hard-TDD protocol is stated and unambiguous, including the gate anchors: check-green before
-  test derivation, the three-part RED exit gate (stable-id coverage, `machinery check --impl`
-  green, red-on-assertions), the GREEN bar of tests plus gate together, and the sequential
-  fallback for runtimes that cannot spawn a fresh-context test-writer.
+  test derivation, the four-part RED exit gate (stable-id coverage, `machinery check --impl`
+  green, red-on-assertions, born clean under the project's own format and lint gates), the GREEN
+  bar of tests plus gate together, and the sequential fallback for runtimes that cannot spawn a
+  fresh-context test-writer.
 
 Before handing back, run the conductor's five-question phase-exit self-review (reality, depth,
 scope, coverage, consistency) over BUILD.md and include the verdicts in your summary.

--- a/docs/brownfield-team-guide.md
+++ b/docs/brownfield-team-guide.md
@@ -175,7 +175,11 @@ design; the tool's contribution is the oracle and its stable ids.
      schedule.
 4. A test becomes LOCKED (the hard-TDD rule: implementers never edit it) at the moment its
    row is adjudicated, not at the moment it is generated. Record verdicts in the PR that
-   introduces the tests. An unadjudicated red test is a question, not a gate.
+   introduces the tests. An unadjudicated red test is a question, not a gate. A file only
+   locks once it is born clean under this project's own formatter and linters and the commit
+   carrying it is green under every non-test gate the project enforces; after the lock there
+   is no legal remedy for a gate the file fails, short of an owner-sanctioned
+   formatting-only amendment with a token-identity proof.
 
 This is the one place this guide deliberately extends SKILL.md: the hard-TDD handoff
 describes greenfield, where every oracle row is normative from birth. On brownfield, rows

--- a/examples/checkout-split/orders/design/BUILD.md
+++ b/examples/checkout-split/orders/design/BUILD.md
@@ -354,11 +354,15 @@ before any test is derived; a red design means the oracle spec cannot be trusted
 design first, never the tests. A test-writer then derives the suite from sections 6 and 7 keyed on
 oracle stable ids (a runtime without subagents runs RED then GREEN sequentially with one agent;
 the derivation rule and the gate runs below are unchanged and separate the phases in place of
-context isolation). RED exits only when all three hold: every oracle stable id appears whole-token
+context isolation). RED exits only when all four hold: every oracle stable id appears whole-token
 in the suite (Gt-tests holds this in the check run), `machinery check design --impl <dir>` is
-green over the scaffolding and stubs the tests compile against, and the suite runs red on
-assertions, never on its own compile or import errors. The tests then lock; the implementer makes
-them pass without editing them. GREEN is accepted only when the locked suite passes AND
+green over the scaffolding and stubs the tests compile against, the suite runs red on
+assertions, never on its own compile or import errors, and the new files are born clean under this
+project's own gates (`gofmt -l` reports nothing over them, `go vet ./...` is clean, and the RED
+commit itself is green under every non-test gate). The tests then lock; the implementer makes
+them pass without editing them. A locked file has no legal remedy for a gate it fails later,
+because nobody is allowed to touch it: that is a RED-phase defect, remedied by an owner-sanctioned
+formatting-only amendment carrying a token-identity proof, never a silent edit. GREEN is accepted only when the locked suite passes AND
 `machinery check design --impl <dir>` is green again: no green path exists that crosses a
 boundary. Generated tests live apart from hand-written ones, so regenerating on a design change
 never clobbers them. A wrong test is a design defect: fix the design, regenerate

--- a/examples/checkout-split/payments/design/BUILD.md
+++ b/examples/checkout-split/payments/design/BUILD.md
@@ -351,11 +351,15 @@ before any test is derived; a red design means the oracle spec cannot be trusted
 design first, never the tests. A test-writer then derives the suite from sections 6 and 7 keyed on
 oracle stable ids (a runtime without subagents runs RED then GREEN sequentially with one agent;
 the derivation rule and the gate runs below are unchanged and separate the phases in place of
-context isolation). RED exits only when all three hold: every oracle stable id appears whole-token
+context isolation). RED exits only when all four hold: every oracle stable id appears whole-token
 in the suite (Gt-tests holds this in the check run), `machinery check design --impl <dir>` is
-green over the scaffolding and stubs the tests compile against, and the suite runs red on
-assertions, never on its own compile or import errors. The tests then lock; the implementer makes
-them pass without editing them. GREEN is accepted only when the locked suite passes AND
+green over the scaffolding and stubs the tests compile against, the suite runs red on
+assertions, never on its own compile or import errors, and the new files are born clean under this
+project's own gates (`gofmt -l` reports nothing over them, `go vet ./...` is clean, and the RED
+commit itself is green under every non-test gate). The tests then lock; the implementer makes
+them pass without editing them. A locked file has no legal remedy for a gate it fails later,
+because nobody is allowed to touch it: that is a RED-phase defect, remedied by an owner-sanctioned
+formatting-only amendment carrying a token-identity proof, never a silent edit. GREEN is accepted only when the locked suite passes AND
 `machinery check design --impl <dir>` is green again: no green path exists that crosses a
 boundary. Generated tests live apart from hand-written ones, so regenerating on a design change
 never clobbers them. A wrong test is a design defect: fix the design, regenerate

--- a/examples/fulfillment/design/BUILD.md
+++ b/examples/fulfillment/design/BUILD.md
@@ -224,12 +224,16 @@ test-writer runs RED then GREEN sequentially with the same single agent; the der
 unchanged (tests come from the oracles, the matrices, and section 6, never from implementation
 intentions), and the gate runs before and after are what separate the phases.
 
-RED exits only when all three deterministic checks hold: every oracle stable id appears whole-token
+RED exits only when all four deterministic checks hold: every oracle stable id appears whole-token
 in the suite (Gt-tests holds this once `machinery check design --impl <dir>` points at the code
 tree), that same check is green over the compile skeleton and stubs the tests stand on (G4-import
-skips test files but checks everything they import), and the suite runs red on failing assertions,
-never on its own compile errors. The tests are then locked; the implementer makes them pass without
-editing them. GREEN is accepted only when the locked suite passes AND
+skips test files but checks everything they import), the suite runs red on failing assertions,
+never on its own compile errors, and the new files are born clean under this project's own gates
+(`mix format --check-formatted` and every linter the umbrella enforces pass over them, and the RED
+commit itself is green under every non-test gate). The tests are then locked; the implementer makes
+them pass without editing them. A locked file has no legal remedy for a gate it fails later,
+because nobody is allowed to touch it: that is a RED-phase defect, remedied by an owner-sanctioned
+formatting-only amendment carrying a token-identity proof, never a silent edit. GREEN is accepted only when the locked suite passes AND
 `machinery check design --impl <dir>` is green again: code that passes the tests by crossing a
 boundary fails the gate; code that respects the boundaries but fails a test is not done. A wrong
 test is a design defect that returns to the design and the formal model. Generated transition tests

--- a/examples/go-crm/design/BUILD.md
+++ b/examples/go-crm/design/BUILD.md
@@ -1059,7 +1059,7 @@ Pin the environment so two implementing agents cannot diverge. The source of tru
    then GREEN sequentially with the same single agent; the derivation rule is unchanged (tests come from
    sections 6-7 and the oracles, never from implementation intentions), and the gate runs in steps 1 and 3
    separate the phases in place of context isolation.
-3. **RED exit gate**, all three deterministic checks required before anything locks:
+3. **RED exit gate**, all four deterministic checks required before anything locks:
    a. Coverage of the spec: every oracle stable id appears whole-token somewhere in the suite (Gt-tests
       holds this deterministically in the step-b check run; a missing id is a missing test); every
       guard-conjunction clause has its falsifying test (the 7 intro a/b/c rule); every invariant in
@@ -1070,9 +1070,16 @@ Pin the environment so two implementing agents cannot diverge. The source of tru
       tests stand on already respect the section 4.5 Architecture Contract (C-ARCH-01).
    c. The suite RUNS and is red for the right reason: failing assertions on missing behavior, never compile
       or import errors inside the tests themselves.
+   d. Born clean: the new test files and their scaffolding already satisfy every gate that will ever be
+      applied to them. `gofmt -l` reports nothing over them, `go vet ./...` is clean, and the RED commit
+      itself is green under every non-test gate this project runs. A locked file has no legal remedy for a
+      gate it fails later, because nobody is allowed to touch it; before the lock is the only time to
+      satisfy those gates.
 4. **The tests are then LOCKED.** The implementer agent may not modify, weaken, skip, or delete them to make
    them pass. Locking is structural (the test files are owned by the test-writer; changes require a design
-   round-trip).
+   round-trip). If a gate later demands a change to a locked file, that is a RED-phase defect and not
+   license to edit: it takes an owner-sanctioned amendment that changes formatting only and carries a
+   token-identity proof (the file's token stream is identical before and after).
 5. **The implementer agent** writes production code until the locked tests pass, honoring the section 4.5
    Architecture Contract (C-ARCH-01) and the section 10 realization rules.
 6. **GREEN acceptance bar**, both together: the locked suite passes AND `machinery check design --impl impl`

--- a/examples/portfolio-engine/design/BUILD.md
+++ b/examples/portfolio-engine/design/BUILD.md
@@ -337,7 +337,7 @@ Target language: Python.
    fresh-context test-writer runs RED then GREEN sequentially with the same single agent; the
    derivation rule is unchanged (tests come from the spec, never from implementation intentions),
    and the gate runs in steps 1 and 3 separate the phases in place of context isolation.
-3. **RED exit gate**, all three checks required before anything locks:
+3. **RED exit gate**, all four checks required before anything locks:
    a. Coverage of the spec: every oracle row's stable id appears whole-token somewhere in the suite
       (Gt-tests holds this deterministically once `--impl` points at the suite), every guard's
       falsifying case has a test, every invariant in section 3 has its `PROP-` property test.
@@ -346,7 +346,15 @@ Target language: Python.
       import), so the suite never forces the implementer to reproduce a boundary violation.
    c. The suite RUNS and is red for the right reason: failing assertions on missing behavior, never
       import or syntax errors inside the tests themselves.
-4. **The tests are then LOCKED.** The implementer may not modify them to pass.
+   d. Born clean: the new test files and their scaffolding already satisfy every gate that will ever
+      be applied to them. `ruff format --check` and `ruff check` are clean over them, `mypy` passes,
+      and the RED commit itself is green under every non-test gate this project runs. A locked file
+      has no legal remedy for a gate it fails later, because nobody is allowed to touch it; before
+      the lock is the only time to satisfy those gates.
+4. **The tests are then LOCKED.** The implementer may not modify them to pass. If a gate later
+   demands a change to a locked file, that is a RED-phase defect and not license to edit: it takes
+   an owner-sanctioned amendment that changes formatting only and carries a token-identity proof
+   (the file's token stream is identical before and after).
 5. **The implementer** writes `pf.model`, `pf.repo`, `pf.feed`, `pf.optimizer`, `pf.domain`,
    `pf.app`, `pf.cli` until the locked tests pass, honoring the Architecture Contract (feed is the
    sole importer of the provider client; repo the sole importer of DuckDB; no cross-boundary edge

--- a/examples/surreal-crm/design/BUILD.md
+++ b/examples/surreal-crm/design/BUILD.md
@@ -1089,7 +1089,7 @@ implementation `go.mod` and the compose file.
    then GREEN sequentially with the same single agent; the derivation rule is unchanged (tests come from
    sections 6-7 and the oracles, never from implementation intentions), and the gate runs in steps 1 and 3
    separate the phases in place of context isolation.
-3. **RED exit gate**, all three deterministic checks required before anything locks:
+3. **RED exit gate**, all four deterministic checks required before anything locks:
    a. Coverage of the spec: every oracle stable id appears whole-token somewhere in the suite (Gt-tests
       holds this deterministically in the step-b check run; a missing id is a missing test); every
       guard-conjunction clause has its falsifying test (the 7 intro a/b/c rule); every invariant in
@@ -1100,9 +1100,16 @@ implementation `go.mod` and the compose file.
       the tests stand on already respect the section 4.5 Architecture Contract (C-ARCH-01).
    c. The suite RUNS and is red for the right reason: failing assertions on missing behavior, never compile
       or import errors inside the tests themselves.
+   d. Born clean: the new test files and their scaffolding already satisfy every gate that will ever be
+      applied to them. `gofmt -l` reports nothing over them, `go vet ./...` is clean, and the RED commit
+      itself is green under every non-test gate this project runs. A locked file has no legal remedy for a
+      gate it fails later, because nobody is allowed to touch it; before the lock is the only time to
+      satisfy those gates.
 4. **The tests are then LOCKED.** The implementer agent may not modify, weaken, skip, or delete them to make
    them pass. Locking is structural (the test files are owned by the test-writer; changes require a design
-   round-trip).
+   round-trip). If a gate later demands a change to a locked file, that is a RED-phase defect and not
+   license to edit: it takes an owner-sanctioned amendment that changes formatting only and carries a
+   token-identity proof (the file's token stream is identical before and after).
 5. **The implementer agent** writes production code until the locked tests pass, honoring the section 4.5
    Architecture Contract (C-ARCH-01) and the section 10 realization rules.
 6. **GREEN acceptance bar**, both together: the locked suite passes AND

--- a/skills/machinery/SKILL.md
+++ b/skills/machinery/SKILL.md
@@ -652,7 +652,12 @@ The protocol is gate-anchored at both ends, and the BUILD.md you produce must sa
 RED is complete only when every oracle stable id appears whole-token in the suite (Gt-tests holds
 this deterministically once `--impl` points at the suite), when
 `machinery check <design> --impl <dir>` is green over the scaffolding and stubs the tests compile
-against, and when the suite is red on assertions rather than its own errors; GREEN is accepted only
+against, when the suite is red on assertions rather than its own errors, and when the new test
+files are born clean under the project's own formatter and linters, with the RED commit itself
+green under every non-test gate the project enforces (a locked file has no legal remedy for a gate
+it fails later, because nobody may touch it; a gate that does demand a change to a locked file is
+a RED-phase defect, remedied by an owner-sanctioned formatting-only amendment carrying a
+token-identity proof, never a silent edit); GREEN is accepted only
 when the locked tests and that same check pass together. This is what makes the discipline hold on
 runtimes that cannot spawn a fresh-context test-writer (Codex and other single-context agents): the
 same agent runs RED then GREEN sequentially, and the deterministic gate runs separate the phases in

--- a/skills/machinery/references/build-md-template.md
+++ b/skills/machinery/references/build-md-template.md
@@ -233,7 +233,7 @@ tools (including how to run `machinery oracle` and `machinery check`).
    derivation rule is unchanged (tests come from sections 6 and 7 and the oracles, never from
    implementation intentions), and the gate runs in steps 1 and 3 are what separate the phases in
    place of context isolation.
-3. RED exit gate, all three deterministic checks required before anything locks:
+3. RED exit gate, all four deterministic checks required before anything locks:
    a. Coverage of the spec: every oracle row's stable id appears whole-token somewhere in the
       suite (Gt-tests holds this deterministically in the step-b check run; a missing id is a
       missing test), every guard-conjunction
@@ -246,10 +246,21 @@ tools (including how to run `machinery oracle` and `machinery check`).
       a boundary violation would force the implementer to reproduce that violation to go green.
    c. The suite RUNS and is red for the right reason: failing assertions on missing behavior,
       never compile or import errors inside the tests themselves.
+   d. Born clean: the new test files and their scaffolding satisfy every project gate that will
+      ever be applied to them. Run this project's formatter and every linter it enforces over the
+      new files, and require the RED commit itself to be green under every non-test gate the
+      project runs (format check, lint, license or copyright headers, encoding and naming rules).
+      A locked file has no legal remedy for a gate it fails later, because nobody is allowed to
+      touch it; the only time to satisfy those gates is before the lock.
    Together these are the guarantee: the spec is gate-checked, the suite's coverage of the spec is
-   id-checked, and the suite's own skeleton respects the architecture, so the implementer has no
-   correct move except delivering the designed behavior inside the designed boundaries.
-4. The tests are then LOCKED. The implementer agent may not modify them to make them pass.
+   id-checked, the suite's own skeleton respects the architecture, and the files are already clean
+   under the project's own gates, so the implementer has no correct move except delivering the
+   designed behavior inside the designed boundaries.
+4. The tests are then LOCKED. The implementer agent may not modify them to make them pass. If a
+   gate later demands a change to a locked file, that is a RED-phase defect and not license to
+   edit: it takes an owner-sanctioned amendment that changes formatting only and carries a
+   token-identity proof (the file's token stream is identical before and after). Anything a
+   formatting-only amendment cannot fix is a design round-trip, per step 8.
 5. The implementer agent writes the code until the locked tests pass.
 6. GREEN acceptance bar, both together: the locked suite passes AND
    `machinery check design --impl <impl-dir>` is green again. Code that passes the tests by


### PR DESCRIPTION
The hard-TDD RED exit gate specified three checks (stable-id coverage, `machinery check --impl` over the scaffolding, red-on-assertions) and said nothing about the gates the project itself runs over its test tree. A test-writer could lock a suite that the project's format or lint gate rejects; the failure then surfaces after GREEN, when the locked file may no longer be touched, and the only remedy left is a delicate formatting-only amendment to a locked file. That is exactly the trap a real project hit.

The rule added, language-agnostically: run the project's formatter and every linter it enforces over the new test files and their scaffolding before the RED commit, and require the RED commit itself to be green under every non-test gate the project runs. Locking now states the single legal post-lock remedy: an owner-sanctioned, formatting-only amendment carrying a token-identity proof, never a silent edit.

Surfaces touched:

- `skills/machinery/references/build-md-template.md` section 11: exit gate is now four checks (new `d.`), and step 4 carries the amendment rule.
- `agents/machinery-build-writer.md`: Method item 11 and the Gate 4 self-check.
- `skills/machinery/SKILL.md`: the gate-anchoring paragraph.
- `docs/brownfield-team-guide.md`: a test locks at adjudication, and only once born clean.
- Every shipped example BUILD.md restates it with that design's actual tools named.

`make preflight` is green locally (it mirrors ci.yml job for job).